### PR TITLE
Change crew-img-container height

### DIFF
--- a/src/assets/sass/components/crew/_crew.scss
+++ b/src/assets/sass/components/crew/_crew.scss
@@ -47,7 +47,7 @@
                 @media screen and (min-width: 768px) {
                     order: 2;
                     border-bottom: none;
-                    height: 532px;
+                    height: 500px;
                 }
                 @media screen and (min-width: 1024px) {
                     width: 40%;


### PR DESCRIPTION
On Chrome on vertical tablet we can scroll because the img was too big, the navbar was trim